### PR TITLE
Fix for checking wrong variable against NULL

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -464,7 +464,7 @@ CURLcode Curl_hyper_header(struct Curl_easy *data, hyper_headers *headers,
     else
       linelen = 2; /* CRLF ending */
     linelen += (p - n);
-    if(!n)
+    if(!p)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     vlen = p - v;
 


### PR DESCRIPTION
Fixes https://github.com/curl/curl/issues/6696


From lib/c-hyper.c:445-467 - n is checked against NULL instead of p, at line 467
I have inserted comments at line 445 and 467.

```C
445    p = strchr(n, ':'); /* <-- n assumed non-NULL here, since dereferenced */
446    if(!p)
447      /* this is fine if we already added at least one header */
448      return numh ? CURLE_OK : CURLE_BAD_FUNCTION_ARGUMENT;
449    nlen = p - n;
450    p++; /* move past the colon */
451    while(*p == ' ')
452      p++;
453    v = p;
454    p = strchr(v, '\r');
455    if(!p) {
456      p = strchr(v, '\n');
457      if(p)
458        linelen = 1; /* LF only */
459      else {
460        p = strchr(v, '\0');
461        newline = FALSE; /* no newline */
462      }
463    }
464    else
465      linelen = 2; /* CRLF ending */
466    linelen += (p - n);
467    if(!n) /* <-- n was assumed non-NULL above, should this have been 'if(!p)' ? */
468      return CURLE_BAD_FUNCTION_ARGUMENT;
469    vlen = p - v; 
```
